### PR TITLE
Adding changes to always resolve tag to latest digest

### DIFF
--- a/pkg/resolve/resolve.go
+++ b/pkg/resolve/resolve.go
@@ -87,7 +87,8 @@ func (f *ImageTagFilter) filterImage(n *yaml.RNode) error {
 	}
 	image := yaml.GetValue(imageNode)
 	if strings.Contains(image, "@") {
-		return nil // already has digest, skip
+                //Change the image in case the tag was pointed to new digest and always pick most recent sha256 value from registry
+                image = strings.Split(image, "@")[0]
 	}
 	digest, err := resolveTagFn(image, f.Keychain)
 	if err != nil {


### PR DESCRIPTION
- Always resolve will help in the situation when the existing tag in resource was forced to point to newer digest in GCR or AR, this will pick up the latest image instead of old image digest. 
- In case the latest digest is still the same, no patch will be applied.