### PR TITLE
Update authentication documentation

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,7 +1,7 @@
 # Authenticating to container image registries
 
 To resolve digests for private images, digester requires credentials to
-authenticate to your container image registry.
+authenticate to container image registries.
 
 ## Authentication modes
 
@@ -19,13 +19,13 @@ node or machine where it runs. This includes the following credentials:
     [Artifact Registry](https://cloud.google.com/artifact-registry/docs).
 
     For implementation details, see the
-    [github.com/google/go-containerregistry/pkg/v1/google](https://pkg.go.github.com/google/go-containerregistry/pkg/v1/google)
+    [github.com/google/go-containerregistry/pkg/v1/google](https://pkg.go.dev/github.com/google/go-containerregistry/pkg/v1/google)
     and
-    [golang.org/x/oauth2/google](https://pkg.go.dev/golang.org/x/oauth2/le)
+    [golang.org/x/oauth2/google](https://pkg.go.dev/golang.org/x/oauth2/google)
     Go packages.
 
 2.  Credentials and credential helpers specified in the
-    [Docker config file](https://github.com/google/go-containerregistry/tree//pkg/authn#the-config-file),
+    [Docker config file](https://github.com/google/go-containerregistry/tree/main/pkg/authn#docker-config-auth),
     for authenticating to any container image registry. The file name is
     `config.json`, and the default file location is the directory
     `$HOME/.docker`. You can override the default location of the config file
@@ -34,8 +34,11 @@ node or machine where it runs. This includes the following credentials:
     For implementation details, see the
     [github.com/google/go-containerregistry/pkg/authn](https://pkg.go.dev/ub.com/google/go-containerregistry/pkg/authn)
     and
-    [github.com/docker/cli/cli/config](https://pkg.go.dev/github.com/docker/cli/config)
+    [github.com/docker/cli/cli/config](https://pkg.go.dev/github.com/docker/cli/cli/config)
     Go packages.
+
+3.   Ambient credentials for GitHub Container Registry (`ghcr.io`),
+     Amazon Elastic Container Registry, and Azure Container Registry.
 
 ### Online authentication
 
@@ -43,28 +46,18 @@ When using online authentication, digester authenticates using the following
 credentials:
 
 1.  The `imagePullSecrets` listed in the
-    [pod specification](https://kubernetes.io/docs/concepts/containers/es/#specifying-imagepullsecrets-on-a-pod)
+    [pod specification](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod)
     and the
-    [service account](https://kubernetes.io/docs/tasks/igure-pod-container/configure-service-account/-imagepullsecrets-to-a-service-account)
+    [service account](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account)
     used by the pod. Digester retrieves these secrets from the Kubernetes
     cluster API server.
 
     For implementation details, see the
-    [github.com/google/go-containerregistry/pkg/authn/k8schain](https://pkg.ev/github.com/google/go-containerregistry/pkg/authn/k8schain)
+    [github.com/google/go-containerregistry/pkg/authn/kubernetes](https://pkg.go.dev/github.com/google/go-containerregistry/pkg/authn/kubernetes)
     Go package.
 
-2.  Cloud provider-specific implementations of the Kubernetes
-    [`DockerConfigProvider` interface](https://pkg.go.dev/github.com/eester/k8s-pkg-credentialprovider#DockerConfigProvider).
-    For instance, the implementation for Google Cloud retrieves credentials
-    from the node or Workload Identity
-    [metadata server](https://cloud.google.com/compute/docs/ing-retrieving-metadata).
-
-    For implementation details, see the provider-specific subdirectories of the
-    [github.com/vdemeester/k8s-pkg-credentialprovider](https://pkg.go.dev/ub.com/vdemeester/k8s-pkg-credentialprovider)
-    Go package.
-
-3.  Credentials specified in the
-    [Docker config file](https://github.com/google/go-containerregistry/tree//pkg/authn#the-config-file),
+2.  Credentials specified in the
+    [Docker config file](https://github.com/google/go-containerregistry/tree/main/pkg/authn#docker-config-auth),
     for authenticating to any container image registry. The file name is
     `config.json`, and the location can be the container working directory
     (`$PWD/config.json`), or a directory called `.docker` under the user
@@ -72,7 +65,22 @@ credentials:
     directory (`/.docker/config.json`).
 
     For implementation details, see the
-    [github.com/vdemeester/k8s-pkg-credentialprovider](https://pkg.go.dev/ub.com/vdemeester/k8s-pkg-credentialprovider)
+    [github.com/google/go-containerregistry/pkg/authn](https://pkg.go.dev/ub.com/google/go-containerregistry/pkg/authn)
+    and
+    [github.com/docker/cli/cli/config](https://pkg.go.dev/github.com/docker/cli/cli/config)
+    Go packages.
+
+3.  Cloud provider-specific instances of the
+    [`Keychain` interface](https://pkg.go.dev/github.com/google/go-containerregistry/pkg/authn#Keychain).
+    For instance, the
+    [implementation for Google](https://pkg.go.dev/github.com/google/go-containerregistry/pkg/v1/google#Keychain)
+    uses Google service account credentials from the file referenced by the
+    [`GOOGLE_APPLICATION_CREDENTIALS` environment variable](https://cloud.google.com/docs/authentication/getting-started#setting_the_environment_variable),
+    or retrieves credentials from the node or Workload Identity
+    [metadata server](https://cloud.google.com/compute/docs/metadata/overview).
+
+    For implementation details, see the
+    [github.com/google/go-containerregistry/pkg/authn/k8schain](https://pkg.go.dev/github.com/google/go-containerregistry/pkg/authn/k8schain)
     Go package.
 
 The client-side KRM function defaults to offline authentication, whereas the

--- a/docs/build.md
+++ b/docs/build.md
@@ -5,32 +5,29 @@ digester.
 
 Before you proceed, clone the Git repository and install the following tools:
 
--   [Go distribution](https://golang.org/doc/install)
--   [ko](https://github.com/google/ko#installation)
--   [kpt](https://kpt.dev/installation/)
+- [Go distribution](https://golang.org/doc/install) v1.17 or later
+- [kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/) v3.7.0 or later 
+- [Skaffold](https://skaffold.dev/docs/install/#standalone-binary) v1.37.2 or later
 
 ## Building binaries and container images
 
--   Build the binary:
+- Build the binary:
 
-    ```sh
-    go build .
-    ```
+  ```sh
+  go build -o digester .
+  ```
 
--  Build a container image and load it into your local Docker daemon:
+- Build a container image and load it into your local Docker daemon:
 
-    ```sh
-    export GOROOT=$(go env GOROOT)
-    ko publish --base-import-paths --local .
-    ```
+  ```sh
+  skaffold build --cache-artifacts=false --push=false
+  ```
 
--   Build a container image and publish it to Container Registry:
+- Build a container image and push it to Container Registry:
 
-    ```sh
-    export GOROOT=$(go env GOROOT)
-    export KO_DOCKER_REPO=gcr.io/$(gcloud config get-value core/project)
-    ko publish --base-import-paths .
-    ```
+  ```sh
+  skaffold build --push --default-repo gcr.io/$(gcloud config get-value core/project)
+  ```
 
 The base image is `gcr.io/distroless/static:nonroot`. If you want to use a
 different base image, change the value of the `defaultBaseImage` field in the
@@ -40,22 +37,7 @@ base image from the `gcr.io/kaniko-project/executor` repository.
 
 ## Building and deploying the webhook
 
-1.  Set environment variables for `ko`:
-
-    ```sh
-    export GOROOT=$(go env GOROOT)
-    export KO_DOCKER_REPO=gcr.io/$(gcloud config get-value core/project)
-    ```
-
-2.  Build and publish the webhook container image, and set the image name (with
-    digest) in the webhook Deployment manifest:
-
-    ```sh
-    IMAGE=$(ko publish --base-import-paths .)
-    kpt fn eval manifests --image gcr.io/kpt-fn/apply-setters:v0.1 -- "image=$IMAGE"
-    ```
-
-3.  (optional) If you use a Google Kubernetes Engine (GKE) cluster with
+1.  (optional) If you use a Google Kubernetes Engine (GKE) cluster with
     [Workload Identity](workload-identity.md), and either Container Registry or
     Artifact Registry, annotate the digester Kubernetes service account:
 
@@ -71,14 +53,8 @@ base image from the `gcr.io/kaniko-project/executor` repository.
     `digester-admin` in the namespace `digester-system` can impersonate the
     Google service account `$GSA`.
 
-4.  Set up inventory tracking for the webhook kpt package:
+2.  Build and push the webhook container image, and deploy to your Kubernetes cluster:
 
     ```sh
-    kpt live init manifests
-    ```
-
-5.  Deploy the webhook:
-
-    ```sh
-    kpt live apply manifests --reconcile-timeout=3m --output=table
+    skaffold run --push --default-repo gcr.io/$(gcloud config get-value core/project)
     ```

--- a/docs/motivation.md
+++ b/docs/motivation.md
@@ -16,7 +16,7 @@ typically [SHA-256](https://wikipedia.org/wiki/SHA-2),
 to the image index, manifest list, or image manifest.
 
 If you are not familiar with image digests, read the document
-[Using container image digests](https://cloud.google.com/solutions/using-container-images).
+[Using container image digests](https://cloud.google.com/architecture/using-container-images).
 
 ## Why deploy with digests instead of tags?
 
@@ -78,10 +78,10 @@ Google Kubernetes Engine (GKE) clusters, you can use
 
 There are many ways to add image digests to Kubernetes manifests. Some of them
 are documented in the tutorial
-[Using container image digests in Kubernetes manifests](https://cloud.google.com/solutions/using-container-image-digests-in-kubernetes-manifests).
+[Using container image digests in Kubernetes manifests](https://cloud.google.com/architecture/using-container-image-digests-in-kubernetes-manifests).
 
 [Cloud Run](https://cloud.google.com/run/docs/deploying#service),
-[Cloud Run for Anthos](https://cloud.google.com/kuberun/docs/deploying#service),
+[Cloud Run for Anthos](https://cloud.google.com/anthos/run/docs/deploying#service),
 and
 [Knative Serving](https://knative.dev/docs/serving/tag-resolution/)
 resolve image tags to digests on deployment. The digest is stored in a service
@@ -89,7 +89,7 @@ revision, and all instances of that service revision use the digest.
 
 ## References
 
--   [Using container image digests](https://cloud.google.com/solutions/using-container-images)
--   [Using container image digests in Kubernetes manifests](https://cloud.google.com/solutions/using-container-image-digests-in-kubernetes-manifests)
+-   [Using container image digests](https://cloud.google.com/architecture/using-container-images)
+-   [Using container image digests in Kubernetes manifests](https://cloud.google.com/architecture/using-container-image-digests-in-kubernetes-manifests)
 -   [k/k#1697: Image name/tag resolution preprocessing pass](https://github.com/kubernetes/kubernetes/issues/1697)
 -   [Why we resolve tags in Knative](https://docs.google.com/presentation/d/e/2PACX-1vTgyp2lGDsLr_bohx3Ym_2mrTcMoFfzzd6jocUXdmWQFdXydltnraDMoLxvEe6WY9pNPpUUvM-geJ-g/pub?resourcekey=0-FH5lN4C2sbURc_ds8XRHeA)

--- a/docs/workload-identity.md
+++ b/docs/workload-identity.md
@@ -33,7 +33,6 @@ as the Container Registry and Artifact Registry image repositories.
 
     gcloud container clusters create digester-webhook-test \
         --enable-ip-alias \
-        --enable-stackdriver-kubernetes \
         --release-channel regular \
         --scopes cloud-platform \
         --workload-pool $PROJECT_ID.svc.id.goog \


### PR DESCRIPTION
The `k8schain` package from `google/go-containerregistry` has made some changes (see google/go-containerregistry#1234). This commit updates the documentation to reflect the new behavior.