### PR TITLE
Avoid panic when kubeconfig is empty in online mode

### DIFF
--- a/cmd/function/function.go
+++ b/cmd/function/function.go
@@ -52,10 +52,15 @@ func createResourceFn(ctx context.Context, log logr.Logger) framework.ResourceLi
 		log.V(2).Info("offline", "offline", viper.GetBool("offline"))
 		var config *rest.Config
 		if !viper.GetBool("offline") {
+			var kubeconfig string
 			var err error
-			kubeconfig := strings.FieldsFunc(viper.GetString("kubeconfig"), func(r rune) bool {
+			kubeconfigs := strings.FieldsFunc(viper.GetString("kubeconfig"), func(r rune) bool {
 				return r == ':' || r == ';'
-			})[0]
+			})
+			if len(kubeconfigs) > 0 {
+				kubeconfig = kubeconfigs[0]
+			}
+			
 			config, err = createConfig(log, kubeconfig)
 			if err != nil {
 				return fmt.Errorf("could not create k8s client config: %w", err)


### PR DESCRIPTION
When the KRM function is used in online mode (`OFFLINE=false`) and the `KUBECONFIG` is empty (because I want to build the kube config from the `rest.InClusterConfig()`), it panics.

```
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/google/k8s-digester/cmd/function.createResourceFn.func1(0xc00046c680)
	github.com/google/k8s-digester/cmd/function/function.go:58 +0x348
...
```

So added a check to only set the kubeconfig when the `kubeconfigs` slice is not empty.