### PR TITLE
Add a flag to ingore failing on errors.

### DIFF
--- a/cmd/webhook/webhook.go
+++ b/cmd/webhook/webhook.go
@@ -77,6 +77,7 @@ var (
 	metricsAddr         string
 	offline             bool
 	port                int
+	ignoreError         bool
 )
 
 func init() {
@@ -88,6 +89,7 @@ func init() {
 	Cmd.Flags().StringVar(&metricsAddr, "metrics-addr", defaultMetricsAddr, "metrics endpoint address")
 	Cmd.Flags().BoolVar(&offline, "offline", false, "do not connect to API server to retrieve imagePullSecrets")
 	Cmd.Flags().IntVar(&port, "port", defaultPort, "webhook server port")
+	Cmd.Flags().BoolVar(&ignoreError, "ignore-error", false, "only log the error; do not fail on the error")
 }
 
 func run(ctx context.Context) error {
@@ -144,7 +146,7 @@ func run(ctx context.Context) error {
 		close(certSetupFinished)
 	}
 
-	go setupControllers(mgr, log, dryRun, certSetupFinished)
+	go setupControllers(mgr, log, dryRun, ignoreError, certSetupFinished)
 
 	log.Info("starting manager")
 	if err := mgr.Start(ctx); err != nil {
@@ -153,7 +155,7 @@ func run(ctx context.Context) error {
 	return nil
 }
 
-func setupControllers(mgr manager.Manager, log logr.Logger, dryRun bool, certSetupFinished chan struct{}) {
+func setupControllers(mgr manager.Manager, log logr.Logger, dryRun bool, ignoreError bool, certSetupFinished chan struct{}) {
 	log.Info("waiting for cert rotation setup")
 	<-certSetupFinished
 	log.Info("done waiting for cert rotation setup")
@@ -162,9 +164,10 @@ func setupControllers(mgr manager.Manager, log logr.Logger, dryRun bool, certSet
 		config = mgr.GetConfig()
 	}
 	whh := &handler.Handler{
-		Log:    log.WithName("webhook"),
-		DryRun: dryRun,
-		Config: config,
+		Log:         log.WithName("webhook"),
+		DryRun:      dryRun,
+		IgnoreError: ignoreError,
+		Config:      config,
 	}
 	mwh := &admission.Webhook{Handler: whh}
 	log.Info("starting webhook server", "path", webhookPath)

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -40,10 +40,10 @@ const (
 
 // Handler implements admission.Handler
 type Handler struct {
-	Log         logr.Logger
-	DryRun      bool
-	IgnoreError bool
-	Config      *rest.Config
+	Log          logr.Logger
+	DryRun       bool
+	IgnoreErrors bool
+	Config       *rest.Config
 }
 
 var resolveImageTags = resolve.ImageTags // override for testing
@@ -99,7 +99,7 @@ func (h *Handler) Handle(ctx context.Context, req admission.Request) admission.R
 }
 
 func (h *Handler) admissionError(err error) admission.Response {
-	if h.IgnoreError {
+	if h.IgnoreErrors {
 		h.Log.Error(err, "ignored admission error")
 		return admission.Allowed(reasonErrorIgnored)
 	}

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -33,15 +33,17 @@ import (
 const (
 	reasonNoMutationForOperation = "NoMutationForOperation"
 	reasonNoSelfManagement       = "NoSelfManagement"
+	reasonErrorIgnored           = "ErrorIgnored"
 	reasonNotPatched             = "NotPatched"
 	reasonPatched                = "Patched"
 )
 
 // Handler implements admission.Handler
 type Handler struct {
-	Log    logr.Logger
-	DryRun bool
-	Config *rest.Config
+	Log         logr.Logger
+	DryRun      bool
+	IgnoreError bool
+	Config      *rest.Config
 }
 
 var resolveImageTags = resolve.ImageTags // override for testing
@@ -97,6 +99,10 @@ func (h *Handler) Handle(ctx context.Context, req admission.Request) admission.R
 }
 
 func (h *Handler) admissionError(err error) admission.Response {
+	if h.IgnoreError {
+		h.Log.Error(err, "ignored admission error")
+		return admission.Allowed(reasonErrorIgnored)
+	}
 	h.Log.Error(err, "admission error")
 	return admission.Errored(int32(http.StatusInternalServerError), err)
 }

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -83,8 +83,8 @@ func Test_Handle_IgnoreError(t *testing.T) {
 		},
 	}
 	h := &Handler{
-		Log:         nullLog, // suppress output of expected error
-		IgnoreError: true,
+		Log:          nullLog, // suppress output of expected error
+		IgnoreErrors: true,
 	}
 
 	resp := h.Handle(ctx, req)

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -73,6 +73,27 @@ func Test_Handle_DisallowedOnParseError(t *testing.T) {
 	assertAdmissionError(t, resp)
 }
 
+func Test_Handle_IgnoreError(t *testing.T) {
+	req := admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Object: runtime.RawExtension{
+				Raw: []byte("\U0001f4a9"),
+			},
+			Operation: admissionv1.Create,
+		},
+	}
+	h := &Handler{
+		Log:         nullLog, // suppress output of expected error
+		IgnoreError: true,
+	}
+
+	resp := h.Handle(ctx, req)
+
+	assertAdmissionAllowed(t, resp)
+	assertReason(t, resp, reasonErrorIgnored)
+	assertNoPatches(t, resp)
+}
+
 func Test_Handle_NoMutationOfDigesterNamespaceRequests(t *testing.T) {
 	req := admission.Request{
 		AdmissionRequest: admissionv1.AdmissionRequest{


### PR DESCRIPTION
When we use the k8s-digester, we find sometimes we do not want it to fail on errors. Making the tag-to-digest conversion at the best effort and logging those errors is enough because those logs can be captured by the log monitoring system.

For example, sometimes k8s-digester does not have permission to read the details of an image, but it can be pulled by the OCI client on the node. In this case, the pod deployment will error out and be blocked forever. Being unable to convert the tag to digest does not always mean that that image is not allowed to be deployed in the K8s cluster.

Unfortunately, there is no way to ignore errors without changing the code. So I create this PR adds a flag to ignore the errors.

/cc @halvards can you take a look? Thank you!