### PR TITLE
Implement --skip-prefixes parameter

### DIFF
--- a/build/examples/pod-diff-registry.yaml
+++ b/build/examples/pod-diff-registry.yaml
@@ -1,0 +1,25 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hello-pod
+spec:
+  containers:
+  - name: busybox
+    image: busybox:latest
+  initContainers:
+  - name: init
+    image: gcr.io/google-samples/hello-app:1.0

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -44,6 +44,7 @@ type Handler struct {
 	DryRun       bool
 	IgnoreErrors bool
 	Config       *rest.Config
+	SkipPrefixes []string
 }
 
 var resolveImageTags = resolve.ImageTags // override for testing
@@ -74,7 +75,7 @@ func (h *Handler) Handle(ctx context.Context, req admission.Request) admission.R
 		return h.admissionError(err)
 	}
 
-	if err = resolveImageTags(ctx, h.Log, h.Config, r); err != nil {
+	if err = resolveImageTags(ctx, h.Log, h.Config, r, h.SkipPrefixes); err != nil {
 		return h.admissionError(err)
 	}
 

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -123,7 +123,7 @@ func Test_Handle_NotPatchedWhenNoChange(t *testing.T) {
 			},
 		},
 	}
-	resolveImageTags = func(_ context.Context, _ logr.Logger, _ *rest.Config, _ *yaml.RNode) error {
+	resolveImageTags = func(_ context.Context, _ logr.Logger, _ *rest.Config, _ *yaml.RNode, _ []string) error {
 		return nil
 	}
 	h := &Handler{Log: log}
@@ -146,7 +146,7 @@ func Test_Handle_Patch(t *testing.T) {
 		},
 	}
 	imageWithDigest := "registry.example.com/repository/image:tag@sha256:digest"
-	resolveImageTags = func(_ context.Context, _ logr.Logger, _ *rest.Config, n *yaml.RNode) error {
+	resolveImageTags = func(_ context.Context, _ logr.Logger, _ *rest.Config, n *yaml.RNode, _ []string) error {
 		return n.PipeE(yaml.Lookup("spec", "containers", "0", "image"), yaml.FieldSetter{StringValue: imageWithDigest})
 	}
 	h := &Handler{Log: log}

--- a/pkg/util/stringarray.go
+++ b/pkg/util/stringarray.go
@@ -1,0 +1,11 @@
+package util
+
+import (
+	"strings"
+)
+
+func StringArray(str string) []string {
+	return strings.FieldsFunc(str, func(r rune) bool {
+		return r == ':' || r == ';'
+	})
+}


### PR DESCRIPTION
* Allows specific image prefixes to be skipped from digest resolution
* Implemented for webhook and kpt
* kpt support also includes environment variable SKIP_PREFIXES bound to the same parameter
* refactors kubeconfig parsing of multi value strings into util.StringArray for reuse